### PR TITLE
Feature/windows dev puppet

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,6 +45,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vbox.memory = 8192
       vbox.cpus = 2
       vbox.gui = false
+      if NETWORK_SETTINGS[:type] == "hostonly"
+        vbox.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+      end
     end
 
     ######################
@@ -102,7 +105,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       when "WINDOWS"
         vmconfig.vm.network "public_network"
       when "LINUX"
-        vmconfig.vm.network "public_network", ip: "#{NETWORK_SETTINGS[:ip_address]}", bridge: "en0: Ethernet"
+        vmconfig.vm.network "public_network", ip: "#{NETWORK_SETTINGS[:ip_address]}"
         # The following is necessary when using the bridged network adapter
         # with Linux in order to make the machine available from other networks.
         config.vm.provision "shell",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -100,7 +100,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if NETWORK_SETTINGS[:type] == "bridged"
       case OPERATING_SYSTEM.upcase
       when "WINDOWS"
-        vmconfig.vm.network "public_network", bridge: "en0: Ethernet"
+        vmconfig.vm.network "public_network"
       when "LINUX"
         vmconfig.vm.network "public_network", ip: "#{NETWORK_SETTINGS[:ip_address]}", bridge: "en0: Ethernet"
         # The following is necessary when using the bridged network adapter
@@ -132,12 +132,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         }
       end
 
-      vmconfig.vm.provision "puppet", type: "shell"  do |puppet|
-        puppet.path = "scripts/provision-puppet.ps1"
-        puppet.upload_path = "C:/temp/provision-puppet.ps1"
-        puppet.env = {
+      vmconfig.vm.provision "yaml", type: "shell"  do |yaml|
+        yaml.path = "scripts/provision-yaml.ps1"
+        yaml.upload_path = "C:/temp/provision-yaml.ps1"
+        yaml.env = {
           "PUPPET_HOME"   => "#{PUPPET_HOME}"
         }
+      end
+
+      vmconfig.vm.provision "puppet" do |puppet|
+        puppet.manifests_path = ["vm", "#{PUPPET_HOME}/manifests"]
+        puppet.manifest_file = "site.pp"
       end
 
       vmconfig.vm.provision "client", type: "shell"  do |client|

--- a/scripts/provision-yaml.ps1
+++ b/scripts/provision-yaml.ps1
@@ -39,7 +39,7 @@ $VerbosePreference = "SilentlyContinue"
 
 #------------------------------------------------------------[Variables]----------------------------------------------------------
 
-$DEBUG = "true"
+$DEBUG = "false"
 
 #-----------------------------------------------------------[Functions]-----------------------------------------------------------
 
@@ -76,4 +76,4 @@ Write-Host "YAML Sync Complete"
 # $port = hiera pia_http_port
 # $sitename = hiera pia_site_name
 
-# Write-Host "Your login URL is http://${fqdn}:${port}/${sitename}/signon.html"
+# Write-Host "Your login URL is http://${fqdn}:${port}/${sitename}/signon.html" -ForegroundColor White

--- a/scripts/provision-yaml.ps1
+++ b/scripts/provision-yaml.ps1
@@ -39,7 +39,7 @@ $VerbosePreference = "SilentlyContinue"
 
 #------------------------------------------------------------[Variables]----------------------------------------------------------
 
-$DEBUG = "false"
+$DEBUG = "true"
 
 #-----------------------------------------------------------[Functions]-----------------------------------------------------------
 
@@ -68,10 +68,12 @@ function execute_puppet_apply() {
 #-----------------------------------------------------------[Execution]-----------------------------------------------------------
 
 . copy_customizations_file
-. execute_puppet_apply
+# . execute_puppet_apply
 
-$fqdn = facter fqdn
-$port = hiera pia_http_port
-$sitename = hiera pia_site_name
+Write-Host "YAML Sync Complete"
 
-Write-Host "Your login URL is http://${fqdn}:${port}/${sitename}/signon.html"
+# $fqdn = facter fqdn
+# $port = hiera pia_http_port
+# $sitename = hiera pia_site_name
+
+# Write-Host "Your login URL is http://${fqdn}:${port}/${sitename}/signon.html"


### PR DESCRIPTION
Move the "puppet apply" step out of a shell script and use the Vagrant built-in Puppet provisioner. 

For VirtualBox and host-only networks, enable `natdnshostresolver1` for DNS lookups on guest VMs.

Close #24
