### PR TITLE
Add RDP to the network_settings default

### DIFF
--- a/config/config.rb.example
+++ b/config/config.rb.example
@@ -107,7 +107,7 @@ DPK_LOCAL_DIR = "dpks" unless defined? DPK_LOCAL_DIR
 #       installation directory) is mounted under "/media/sf_*".
 DPK_REMOTE_DIR_LNX = "/media/sf_#{DPK_VERSION}" unless defined? DPK_REMOTE_DIR
 DPK_REMOTE_DIR_WIN = "C:/psft/dpks/#{DPK_VERSION}" unless defined? DPK_REMOTE_DIR
-NETWORK_SETTINGS = { :type => "hostonly", :host_http_port => "8000", :guest_http_port => "8000", :host_listener_port => "1522", :guest_listener_port => "1522" } unless defined? NETWORK_SETTINGS
+NETWORK_SETTINGS = { :type => "hostonly", :host_http_port => "8000", :guest_http_port => "8000", :host_listener_port => "1522", :guest_listener_port => "1522", :host_rdp_port => "33389", :guest_rdp_port => "3389"} unless defined? NETWORK_SETTINGS
 
 DPK_BOOTSTRAP = 'true' unless defined? DPK_BOOTSTRAP
 PUPPET_APPLY = 'true' unless defined? PUPPET_APPLY


### PR DESCRIPTION
The defaults were missing RDP and causing the Vagrantfile to fail validation.