### PR TITLE
Changed download folder to `dpk/download`.

### DIFF
--- a/config/config.rb.example
+++ b/config/config.rb.example
@@ -102,11 +102,11 @@ PATCH_ID='23711856'
 OPERATING_SYSTEM = "LINUX" unless defined? OPERATING_SYSTEM
 FQDN = 'psvagabond' unless defined? FQDN
 DPK_VERSION = PATCH_ID unless defined? DPK_VERSION
-DPK_LOCAL_DIR = "dpks" unless defined? DPK_LOCAL_DIR
+DPK_LOCAL_DIR = "dpk/download" unless defined? DPK_LOCAL_DIR
 # NOTE: The pum setup script for linux will fail unless the DPK_REMOTE_DIR (DPK
 #       installation directory) is mounted under "/media/sf_*".
 DPK_REMOTE_DIR_LNX = "/media/sf_#{DPK_VERSION}" unless defined? DPK_REMOTE_DIR
-DPK_REMOTE_DIR_WIN = "C:/psft/dpks/#{DPK_VERSION}" unless defined? DPK_REMOTE_DIR
+DPK_REMOTE_DIR_WIN = "C:/psft/dpk/download/#{DPK_VERSION}" unless defined? DPK_REMOTE_DIR
 NETWORK_SETTINGS = { :type => "hostonly", :host_http_port => "8000", :guest_http_port => "8000", :host_listener_port => "1522", :guest_listener_port => "1522", :host_rdp_port => "33389", :guest_rdp_port => "3389"} unless defined? NETWORK_SETTINGS
 
 DPK_BOOTSTRAP = 'true' unless defined? DPK_BOOTSTRAP


### PR DESCRIPTION
This change is to clean up the base folder. There is a `dpk` folder
we should use (instead of `dpks`). This change will also work better
with Puppet 4 changes coming in 8.56. We can also have a `dpk/puppet`
folder for custom manifests we want to deploy.