### PR TITLE
Feature/2016 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,11 @@ Vagabond supports the Linux and Windows NativeOS Deployment Packages. By default
 # OPERATING_SYSTEM
 # Which OS to use as the base box for the DPK.  The available options
 # are either 'LINUX' (Oracle Enterprise Linux 7.x) or 'WINDOWS'
-# (Windows 2012 R2). If left undefined, it will default to Linux.
+# (Windows 2012 R2 or Windows 2016).
+# If left undefined, it will default to Linux.
 OPERATING_SYSTEM = 'WINDOWS'
+# Two Windows Versions are supported, "2012R2" and "2016"
+# WIN_VERSION = "2016"
 ```
 
 The Windows virtual machine is an evaulation version of Windows 2012 R2 and is only intended for demonstration purposes. [You can build your own base Windows VM](https://www.vagrantup.com/docs/virtualbox/boxes.html) with a licensed copy of Windows to use for testing and production support.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,11 +55,19 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ######################
 
     case OPERATING_SYSTEM.upcase
-    when "WINDOWS"
-      # Base box
-      vmconfig.vm.box = "psadmin-io/ps-vagabond-win"
-      # vmconfig.vm.box_check_update = true
-      vmconfig.vm.box_version = "1.0.4"
+    when "WINDOWS"      
+      case WIN_VERSION.upcase
+      when "2012R2"
+        # Base box
+        vmconfig.vm.box = "psadmin-io/ps-vagabond-win"
+        # vmconfig.vm.box_check_update = true
+        vmconfig.vm.box_version = "1.0.5"
+      when "2016"
+        # Base box
+        vmconfig.vm.box = "psadmin-io/ps-vagabond-win-2016"
+        # vmconfig.vm.box_check_update = true
+        vmconfig.vm.box_version = "1.0.0"
+      end
       # Sync folder to be used for downloading the dpks
       vmconfig.vm.synced_folder "#{DPK_LOCAL_DIR}", "#{DPK_REMOTE_DIR_WIN}"
       # WinRM communication settings

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -245,22 +245,23 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         end
       end
 
-      vmconfig.vm.provision "client", type: "shell"  do |client|
-        client.path        = "scripts/provision-client.ps1"
-        client.upload_path = "C:/temp/provision-client.ps1"
-        client.privileged  = "true"
-        client.env = {
-          "CA_SETUP"       => "#{CA_SETTINGS[:setup]}",
-          "CA_PATH"        => "#{CA_SETTINGS[:path]}",
-          "CA_TYPE"        => "#{CA_SETTINGS[:type]}",
-          "CA_BACKUP"      => "#{CA_SETTINGS[:backup]}",
-          "IE_HOMEPAGE"    => "#{IE_HOMEPAGE}",
-          "PTF_SETUP"      => "#{PTF_SETUP}"
-        }
+      if CLIENT_TOOLS.downcase == 'true'
+        vmconfig.vm.provision "client", type: "shell"  do |client|
+          client.path        = "scripts/provision-client.ps1"
+          client.upload_path = "C:/temp/provision-client.ps1"
+          client.privileged  = "true"
+          client.env = {
+            "CA_SETUP"       => "#{CA_SETTINGS[:setup]}",
+            "CA_PATH"        => "#{CA_SETTINGS[:path]}",
+            "CA_TYPE"        => "#{CA_SETTINGS[:type]}",
+            "CA_BACKUP"      => "#{CA_SETTINGS[:backup]}",
+            "IE_HOMEPAGE"    => "#{IE_HOMEPAGE}",
+            "PTF_SETUP"      => "#{PTF_SETUP}"
+          }
+        end
       end
 
       if APPLY_PT_PATCH.downcase == 'true'
-
         vmconfig.vm.provision "dpk-modules-ptp", type: "shell"  do |yaml|
           yaml.path = "scripts/provision-dpk-modules.ps1"
           yaml.upload_path = "C:/temp/provision-dpk-modules.ps1"

--- a/config/config.rb.example
+++ b/config/config.rb.example
@@ -104,6 +104,11 @@ PATCH_ID='23711856'
 #       VirtualBox will error if the hostname has "." in it
 # FQDN='psvagabond'
 
+# CLIENT_TOOLS
+# Set CLIENT_TOOLS to true if you want the PeopleTools Client to 
+# be installed
+# CLIENT_TOOLS = 'true'
+
 # CA_SETTINGS
 # Uncomment and modify the following to setup Change Assistant.
 #CA_SETTINGS = {

--- a/config/config.rb.example
+++ b/config/config.rb.example
@@ -32,6 +32,8 @@ PATCH_ID='23711856'
 # are either 'LINUX' (Oracle Enterprise Linux 7.x) or 'WINDOWS'
 # (Windows 2012 R2). If left undefined, it will default to Linux.
 #OPERATING_SYSTEM = 'WINDOWS'
+# Two Windows Versions are supported, "2012R2" and "2016"
+# WIN_VERSION = "2016"
 
 # DPK_VERSION
 # A name describing which dpk is being used. This is primarily used for
@@ -123,6 +125,7 @@ PATCH_ID='23711856'
 ##############
 # All of the settings below should be left as-is
 OPERATING_SYSTEM = "LINUX" unless defined? OPERATING_SYSTEM
+WIN_VERSION = "2016" unless defined? WIN_VERSION
 FQDN = 'psvagabond' unless defined? FQDN
 DPK_VERSION = PATCH_ID unless defined? DPK_VERSION
 DPK_LOCAL_DIR = "dpk/download" unless defined? DPK_LOCAL_DIR


### PR DESCRIPTION
* A packer image was built for Windows 2016 - `psadmin-io\ps-vagabond-win-2016`
* A new configuration option was added to select the Windows version. New default is 2016.
* Added configuration option for client tools install