### PR TITLE
Make example YAML work with default build (Linux)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ config/client.reg
 
 # Local notes file
 NOTES.md
+
+# Vagrant boxes
+*.box

--- a/config/config.rb.example
+++ b/config/config.rb.example
@@ -71,7 +71,9 @@ PATCH_ID='23711856'
   #:host_listener_port => "1522",
   #:guest_listener_port => "1522",
   #:host_rdp_port => "33389",
-  #:guest_rdp_port => "3389"
+  #:guest_rdp_port => "3389",
+  #:host_es_port => "9200",
+  #:guest_es_port => "9200"
 #}
 
 # BRIDGED NETWORK_SETTINGS
@@ -138,7 +140,7 @@ DPK_LOCAL_DIR = "dpk/download" unless defined? DPK_LOCAL_DIR
 #       installation directory) is mounted under "/media/sf_*".
 DPK_REMOTE_DIR_LNX = "/media/sf_#{DPK_VERSION}" unless defined? DPK_REMOTE_DIR
 DPK_REMOTE_DIR_WIN = "C:/psft/dpk/download/#{DPK_VERSION}" unless defined? DPK_REMOTE_DIR
-NETWORK_SETTINGS = { :type => "hostonly", :host_http_port => "8000", :guest_http_port => "8000", :host_listener_port => "1522", :guest_listener_port => "1522", :host_rdp_port => "33389", :guest_rdp_port => "3389"} unless defined? NETWORK_SETTINGS
+NETWORK_SETTINGS = { :type => "hostonly", :host_http_port => "8000", :guest_http_port => "8000", :host_listener_port => "1522", :guest_listener_port => "1522", :host_rdp_port => "33389", :guest_rdp_port => "3389", :host_es_port => "9200", :guest_es_port => "9200"} unless defined? NETWORK_SETTINGS
 
 DPK_BOOTSTRAP = 'true' unless defined? DPK_BOOTSTRAP
 PUPPET_APPLY = 'true' unless defined? PUPPET_APPLY

--- a/config/psft_customizations.yaml.example
+++ b/config/psft_customizations.yaml.example
@@ -1,7 +1,11 @@
 ---
-peoplesoft_base:   c:/psft
+#peoplesoft_base:   c:/psft
+#ps_config_home:    "%{hiera('peoplesoft_base')}/cfg"
+
 db_name:           PSFTDB
 db_name_downcase:  psftdb
+db_port:           1522
+
 psft_db:
   location:        "%{hiera('psft_db_location')}"
   # container_name:  CDBELM   # can specify or it will be built using CDB+type
@@ -15,7 +19,6 @@ access_id:         SYSADM
 access_pwd:        SYSADM
 
 pia_webprofile_name:    DEV
-ps_config_home:         "%{hiera('peoplesoft_base')}/cfg"
 
 appserver_domain_name:   "%{hiera('db_name_downcase')}"
 prcs_domain_name:        "%{hiera('db_name_downcase')}"
@@ -36,7 +39,7 @@ ps_home:
 ps_app_home:  
   location:    "%{hiera('peoplesoft_base')}/pt/ps_app_home"
 
-db_service_name: "PSFTDB"
+db_service_name: "%{hiera('db_name')}"
 
 tns_admin_list:
   "%{hiera('db_name')}":


### PR DESCRIPTION
The example YAML file had a few bugs that created errors when building with the default settings (Linux). 

* Set Listener Port 1522 instead of 1521 (Vagrant sets 1522 for the port forward)
* Commented out Windows `peoplesoft_base` and `ps_confg_home`
* DB Service Name defaults to `db_name` value

Added port 9200 to Host-Only network port forwarding.