### PR TITLE
Bump ps-vagabond-win-2016 to v1.0.1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,8 +65,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       when "2016"
         # Base box
         vmconfig.vm.box = "psadmin-io/ps-vagabond-win-2016"
-        # vmconfig.vm.box_check_update = true
-        vmconfig.vm.box_version = "1.0.0"
+        vmconfig.vm.box_check_update = true
+        vmconfig.vm.box_version = "1.0.1"
       end
       # Sync folder to be used for downloading the dpks
       vmconfig.vm.synced_folder "#{DPK_LOCAL_DIR}", "#{DPK_REMOTE_DIR_WIN}"


### PR DESCRIPTION
Rebuilt the `ps-vagabond-win-2016` box to extend the evaluation period. Using new `v1.0.1` box version.

Also enabled `box_check_update` for `ps-vagabond-win-2016`.

