### PR TITLE
pre-make PS_CFG_HOME

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -304,7 +304,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           "MOS_USERNAME" => "#{MOS_USERNAME}",
           "MOS_PASSWORD" => "#{MOS_PASSWORD}",
           "PATCH_ID"     => "#{PATCH_ID}",
-          "DPK_INSTALL"  => "#{DPK_REMOTE_DIR_LNX}/#{PATCH_ID}"
+          "DPK_INSTALL"  => "#{DPK_REMOTE_DIR_LNX}/#{PATCH_ID}",
+          "PSFT_CFG_DIR" => "#{PSFT_CFG_DIR}"
         }
       end
     else

--- a/config/config.rb.example
+++ b/config/config.rb.example
@@ -11,8 +11,8 @@
 # MOS username and password must be specified in order to
 # download the DPK files from Oracle.
 
-MOS_USERNAME='USER@EXAMPLE.COM'
-MOS_PASSWORD='MYMOSPASSWORD'
+#MOS_USERNAME='USER@EXAMPLE.COM'
+#MOS_PASSWORD='MYMOSPASSWORD'
 
 # Alternatively, if you wish to store your credentials in environment
 # variables simply remove the above lines and uncomment the two
@@ -39,7 +39,7 @@ PATCH_ID='23711856'
 # A name describing which dpk is being used. This is primarily used for
 # defining the virtual machine name to be used within VirtualBox. If
 # undefined it will default to the PATCH_ID.
-#DPK_VERSION = 'FSCM92'
+#DPK_VERSION = 'VMNAME'
 
 # PSFT_BASE_DIR
 # the base folder where the DPK will install software
@@ -88,7 +88,7 @@ PATCH_ID='23711856'
 # DPK_LOCAL_DIR
 # The directory location (relative to the host machine) to download and extract the dpk
 # files. This defaults to the "dpks/<patch_id>" directory from where ps-vagabond is started.
-# DPK_LOCAL_DIR = 'C:/peoplesoft/dpks/fn92u020'
+# DPK_LOCAL_DIR = 'C:/psft/dpks'
 
 # DPK_REMOTE_DIR
 # The directory location on the virtual machine where the dpk files will be

--- a/config/psft_customizations.yaml.example
+++ b/config/psft_customizations.yaml.example
@@ -1,6 +1,14 @@
 ---
+#peoplesoft_base:   /opt/oracle/psft
 #peoplesoft_base:   c:/psft
-#ps_config_home:    "%{hiera('peoplesoft_base')}/cfg"
+
+#ps_config_home:         "%{hiera('peoplesoft_base')}/cfg"
+#ps_home_location:       "%{hiera('pt_location')}/..."
+#inventory_location:     "%{hiera('db_location')}/oraInventory"
+#oracle_client_location: "%{hiera('pt_location')}/oracle-client/..."
+#jdk_location:           "%{hiera('pt_location')}/jdk"
+#weblogic_location:      "%{hiera('pt_location')}/wls"
+#tuxedo_location:        "%{hiera('pt_location')}/tux"
 
 db_name:           PSFTDB
 db_name_downcase:  psftdb

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -39,6 +39,7 @@ readonly PATCH_FILE_LIST="${TMPDIR}/file_list"
 readonly PSFT_BASE_DIR="/opt/oracle/psft"
 readonly VAGABOND_STATUS="${DPK_INSTALL}/vagabond.json"
 readonly CUSTOMIZATION_FILE="/vagrant/config/psft_customizations.yaml"
+readonly PSFT_CFG_DIR="${PSFT_CFG_DIR}"
 
 declare -a additional_packages=("vim-enhanced" "htop" "jq" "python-pip" "PyYAML" "python-requests")
 declare -A timings
@@ -316,6 +317,28 @@ function execute_puppet_apply() {
   timings[execute_puppet_apply]=$tottime
 }
 
+function execute_pre_setup() {
+  local begin=$(date +%s)
+  echoinfo "Executing Pre setup script"
+  if [[ -n ${DEBUG+x} ]]; then
+    if [ ! -z "${PSFT_CFG_DIR}" ]; then
+      echodebug "Pre making PS_CFG_HOME"
+      sudo mkdir -pv "${PSFT_CFG_DIR}"
+      sudo chmod -v 777 "${PSFT_CFG_DIR}"
+    else
+      echodebug 'Skipping pre make PS_CFG_HOME, $PSFT_CFG_DIR not set.'
+    fi
+  else
+    if [ ! -z "${PSFT_CFG_DIR}" ]; then
+      sudo mkdir -p "${PSFT_CFG_DIR}" > /dev/null 2>&1
+      sudo chmod 777 "${PSFT_CFG_DIR}" > /dev/null 2>&1
+    fi
+  fi
+  local end=$(date +%s)
+  local tottime="$((end - begin))"
+  timings[execute_pre_setup]=$tottime
+}
+
 function execute_psft_dpk_setup() {
   local begin=$(date +%s)
   echoinfo "Setting file execution attribute on psft-dpk-setup.sh"
@@ -434,6 +457,7 @@ determine_tools_version
 determine_puppet_home
 
 # Running the setup script
+execute_pre_setup
 execute_psft_dpk_setup
 
 # Postrequisite fixes


### PR DESCRIPTION
By default DPK creates `PS_CFG_HOME` under the `psadm2` home directory. Because of this, it makes assumptions that `psadm2` has permission to create directories when creating `PS_CFG_HOME`. If we want this directory located elsewhere, say under `$PSFT_BASE_DIR/cfg`, this could be an invalid assumption.

This commit adds the ability to pre make the `PS_CFG_HOME` directory, if specified in the config. So, when the DPK runs it will have correct permission and ability to create `PS_CFG_HOME`.

Also, example cleanup.