### PR TITLE
Add support for 8.58-based images

### DIFF
--- a/scripts/provision-bootstrap-ps.ps1
+++ b/scripts/provision-bootstrap-ps.ps1
@@ -72,10 +72,7 @@ function determine_puppet_home() {
         "55" { 
             $PUPPET_HOME = "C:\ProgramData\PuppetLabs\puppet\etc"
         }
-        "56" {
-            $PUPPET_HOME = "${PSFT_BASE_DIR}/dpk/puppet"
-        }
-        "57" {
+        {$_ -in "56", "57", "58"} {
             $PUPPET_HOME = "${PSFT_BASE_DIR}/dpk/puppet"
         }
         Default { Write-Host "PeopleTools version could not be determined in the bs-manifest file."}
@@ -119,8 +116,8 @@ function execute_psft_dpk_setup() {
   Write-Host "DPK INSTALL: ${DPK_INSTALL}"
 
   switch ($TOOLS_MINOR_VERSION) {
-    "57" {
-        Write-Host "Running PeopleTools 8.57 Bootstrap Script"
+    {$_ -in "56", "57", "58"} {
+        Write-Host "Running PeopleTools 8.$_ Bootstrap Script"
         if ($DEBUG -eq "true") {
             . "${DPK_INSTALL}/setup/psft-dpk-setup.bat" `
             --silent `
@@ -134,23 +131,7 @@ function execute_psft_dpk_setup() {
             --response_file "${DPK_INSTALL}/response.cfg" `
             --no_puppet_run 2>&1 | out-null
         }
-    } 
-    "56" {
-        Write-Host "Running PeopleTools 8.56 Bootstrap Script"
-        if ($DEBUG -eq "true") {
-            . "${DPK_INSTALL}/setup/psft-dpk-setup.bat" `
-            --silent `
-            --dpk_src_dir "${DPK_INSTALL}" `
-            --response_file "${DPK_INSTALL}/response.cfg" `
-            --no_puppet_run
-        } else {
-            . "${DPK_INSTALL}/setup/psft-dpk-setup.bat" `
-            --dpk_src_dir ${DPK_INSTALL} `
-            --silent `
-            --response_file "${DPK_INSTALL}/response.cfg" `
-            --no_puppet_run 2>&1 | out-null
-        }
-    } 
+    }  
     "55" {
         if ($DEBUG -eq "true") {
             . "${DPK_INSTALL}/setup/psft-dpk-setup.ps1" `

--- a/scripts/provision-puppet-apply.ps1
+++ b/scripts/provision-puppet-apply.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Version 5
+#Requires -Version 5
 
 <#PSScriptInfo
 
@@ -65,10 +65,7 @@ function determine_puppet_home() {
       "55" { 
         $PUPPET_HOME = "C:\ProgramData\PuppetLabs\puppet\etc"
       }
-      "56" {
-        $PUPPET_HOME = "${PSFT_BASE_DIR}/dpk/puppet"
-      }
-      "57" {
+      {$_ -in "56", "57", "58"} {
         $PUPPET_HOME = "${PSFT_BASE_DIR}/dpk/puppet"
       }
       Default { Write-Host "PeopleTools version could not be determined in the bs-manifest file."}
@@ -86,16 +83,7 @@ function execute_puppet_apply() {
   $env:PATH = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
 
   switch ($TOOLS_MINOR_VERSION) {
-    "57" {
-      if ($DEBUG -eq "true") {
-        . refreshenv
-        puppet apply "${PUPPET_HOME}\production\manifests\site.pp" --confdir="${PUPPET_HOME}" --trace --debug
-      } else {
-        . refreshenv | out-null
-        puppet apply "${PUPPET_HOME}\production\manifests\site.pp" 2>&1 | out-null
-      }
-    }
-    "56" {
+    {$_ -in "56", "57", "58"} {
       if ($DEBUG -eq "true") {
         . refreshenv
         puppet apply "${PUPPET_HOME}\production\manifests\site.pp" --confdir="${PUPPET_HOME}" --trace --debug

--- a/scripts/provision-yaml.ps1
+++ b/scripts/provision-yaml.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Version 5
+#Requires -Version 5
 
 <#PSScriptInfo
 
@@ -64,10 +64,7 @@ function determine_puppet_home() {
       "55" { 
           $PUPPET_HOME = "C:\ProgramData\PuppetLabs\puppet\etc"
        }
-      "56" {
-        $PUPPET_HOME = "${PSFT_BASE_DIR}/dpk/puppet"
-      }
-      "57" {
+      {$_ -in "56", "57", "58"} {
         $PUPPET_HOME = "${PSFT_BASE_DIR}/dpk/puppet"
       }
       Default { Write-Host "PeopleTools version could not be determined in the bs-manifest file."}
@@ -85,21 +82,10 @@ function determine_puppet_home() {
 function copy_customizations_file() {
   Write-Host "Copying customizations file"
   switch ($TOOLS_MINOR_VERSION) {
-    "57" {
+    {$_ -in "56", "57", "58"} {
       if (!(Test-Path $PUPPET_HOME\production\data)) {
         New-Item -ItemType directory -Path $PUPPET_HOME\production\data
       }
-      if ($DEBUG -eq "true") {
-        Write-Host "Copying to ${PUPPET_HOME}\production\data"
-        Copy-Item "c:\vagrant\config\psft_customizations.yaml" "${PUPPET_HOME}\production\data\psft_customizations.yaml" -Force
-      } else {
-        Copy-Item "c:\vagrant\config\psft_customizations.yaml" "${PUPPET_HOME}\production\data\psft_customizations.yaml" -Force 2>&1 | out-null
-      }
-    }
-    "56" {
-        if (!(Test-Path $PUPPET_HOME\production\data)) {
-          New-Item -ItemType directory -Path $PUPPET_HOME\production\data
-        }
       if ($DEBUG -eq "true") {
         Write-Host "Copying to ${PUPPET_HOME}\production\data"
         Copy-Item "c:\vagrant\config\psft_customizations.yaml" "${PUPPET_HOME}\production\data\psft_customizations.yaml" -Force


### PR DESCRIPTION
I received the following error when I attempted to deploy the CS 17 Windows Native OS image:

```
PeopleTools version could not be determined in the bs-manifest file.
```

CS 17 uses 8.58.03 and the Vagabond scripts did not have logic to handle this version.  I added the check for the "58" version in the various switch statements and performed the same action that occurs for the "56" and "57" version conditions.  I went ahead and combined the conditions in the switch statements for these 3 versions as their action logic is identical.

I was able to successfully deploy the CS 17 Windows Native OS image with these changes in place.