### PR TITLE
Move Networking Provisioning Into a Script 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -142,7 +142,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         host: NETWORK_SETTINGS[:host_kb_port]
       vmconfig.vm.provision "domain_resolver", type: "shell", run: "once",
         inline: "echo search #{NETWORK_SETTINGS[:domain]} | tee -a /etc/resolv.conf"
-      vmconfig.vm.provision "hostname_resolver", type: "shell", run: "once",
+      vmconfig.vm.provision "hostname_resolver", type: "shell", keep_color: true, run: "once",
         inline: "privateip=$(ifconfig eth0 | grep 'inet ' | cut -d' ' -f10) && echo add \"\'${privateip} $(hostname).#{NETWORK_SETTINGS[:domain]}\'\" to your hosts file"
     end
 
@@ -159,8 +159,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           inline: "nmcli connection modify \"System eth0\" ipv4.never-default yes && nmcli connection modify \"System eth1\" ipv4.gateway #{NETWORK_SETTINGS[:gateway]} && nmcli networking off && nmcli networking on"
         vmconfig.vm.provision "domain_resolver", type: "shell", run: "once",
           inline: "echo search #{NETWORK_SETTINGS[:domain]} | tee -a /etc/resolv.conf"
-        vmconfig.vm.provision "hostname_resolver", type: "shell", run: "once",
-          inline: "nameserver=$(cat /etc/resolv.conf | grep search | tail -n1 | gawk -F' ' '{ print $2 }') && echo 127.0.0.1 $(hostname).${nameserver} | tee -a /etc/hosts && echo add \"\'#{NETWORK_SETTINGS[:ip_address]} $(hostname).${nameserver}\'\" to your hosts file"
+        vmconfig.vm.provision "hostname_resolver", type: "shell", keep_color: true, run: "once",
+          inline: "nameserver=$(cat /etc/resolv.conf | grep search | tail -n1 | gawk -F' ' '{ print $2 }') && echo #{NETWORK_SETTINGS[:ip_address]} $(hostname).${nameserver} | tee -a /etc/hosts && echo -e \e[1,36m ===> add \"\'#{NETWORK_SETTINGS[:ip_address]} $(hostname).${nameserver}\'\" to your hosts file \e[0m"
       else
         raise Vagrant::Errors::VagrantError.new, "Operating System #{OPERATING_SYSTEM} is not supported"
       end
@@ -171,7 +171,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vmconfig.vm.network "private_network", ip: "#{NETWORK_SETTINGS[:ip_address]}", virtualbox__intnet: "public"
       vmconfig.vm.provision "domain_resolver", type: "shell", run: "once",
         inline: "echo search #{NETWORK_SETTINGS[:domain]} | tee -a /etc/resolv.conf"
-      vmconfig.vm.provision "hostname_resolver", type: "shell", run: "once",
+      vmconfig.vm.provision "hostname_resolver", type: "shell", keep_color: true, run: "once",
         inline: "privateip=$(ifconfig eth0 | grep 'inet ' | cut -d' ' -f10) && echo add \"\'${privateip} $(hostname).#{NETWORK_SETTINGS[:domain]}\'\" to your hosts file"
 
     end

--- a/scripts/networking.sh
+++ b/scripts/networking.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# shellcheck disable=2059,2154,2034,2155,2046,2086
+#===============================================================================
+# vim: softtabstop=2 shiftwidth=2 expandtab fenc=utf-8 spelllang=en ft=sh
+#===============================================================================
+#
+#          FILE: networking.sh
+#
+#         USAGE: ./networking.sh
+#
+#   DESCRIPTION: Configure bridge networking on the vagrant box
+#
+#===============================================================================
+
+set -e          # Exit immediately on error
+set -u          # Treat unset variables as an error
+set -o pipefail # Prevent errors in a pipeline from being masked
+IFS=$'\n\t'     # Set the internal field separator to a tab and newline
+
+###############
+#  Variables  #
+###############
+
+# export DEBUG=true
+
+###############
+#  Functions  #
+###############
+
+function echoinfo() {
+  local GC="\033[1;32m"
+  local EC="\033[0m"
+  printf "${GC} ☆  INFO${EC}: %s${GC}\n" "$@";
+}
+
+function echodebug() {
+  local BC="\033[1;34m"
+  local EC="\033[0m"
+  local GC="\033[1;32m"
+  if [[ -n ${DEBUG+x} ]]; then
+    printf "${BC} ★  DEBUG${EC}: %s${GC}\n" "$@";
+  fi
+}
+
+function echoerror() {
+  local RC="\033[1;31m"
+  local EC="\033[0m"
+  printf "${RC} ✖  ERROR${EC}: %s\n" "$@" 1>&2;
+}
+
+function set_gateway() {
+  nmcli connection modify "System eth0" ipv4.never-default yes 
+  nmcli connection modify "System eth0" ipv4.gateway $GATEWAY 
+  nmcli networking off 
+  nmcli networking on
+}
+
+function set_hostname_resolver() {
+  echodebug "Setting domain to ${DOMAIN}"
+  echo search $DOMAIN | tee -a /etc/resolv.conf
+}
+
+function set_bridged_hostname() {
+  nameserver=$(grep search /etc/resolv.conf | tail -n1 | gawk -F' ' '{ print $2 }')
+  echo $IP_ADDRESS $(hostname) $(hostname).${nameserver} | tee -a /etc/hosts > /dev/null 2>&1
+  echoinfo
+  echoinfo
+  echoinfo "===> Add '${IP_ADDRESS} $(hostname) $(hostname).${nameserver}' to your hosts file"
+  echoinfo
+  echoinfo
+}
+
+function set_private_hostname() {
+  privateip=$(ifconfig eth0 | grep 'inet ' | cut -d' ' -f10)
+  echo $privateip $(hostname) $(hostname).$DOMAIN | tee -a /etc/hosts > /dev/null 2>&1
+  echoinfo
+  echoinfo
+  echoinfo "===> Add '${privateip} $(hostname) $(hostname).$DOMAIN' to your hosts file"
+  echoinfo
+  echoinfo
+}
+
+##########
+#  Main  #
+##########
+
+set_hostname_resolver
+
+case ${NETWORK_SETTINGS} in
+    "bridged" )
+      set_gateway
+      set_bridged_hostname
+      ;;
+    "private" | "hostonly" )
+      set_private_hostname
+      ;;
+esac
+

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -470,7 +470,7 @@ function install_psadmin_plus(){
         curl --insecure https://rubygems.org/downloads/psadmin_plus-2.0.5.gem -o psadmin_plus.gem > /dev/null 2>&1
         sudo $PSFT_BASE_DIR/psft_puppet_agent/bin/gem install --local psadmin_plus.gem > /dev/null 2>&1
       fi
-      echo "PATH=$PATH:$PSFT_BASE_DIR/psft_puppet_agent/bin" | tee -a ~/.bash_profile > /dev/null 2>&1
+      echo "PATH=$PATH:$PSFT_BASE_DIR/psft_puppet_agent/bin" | tee -a /home/vagrant/.bash_profile > /dev/null 2>&1
       ;;
     * )
       echo "Tools Version not supported"


### PR DESCRIPTION
* The network provisioners are now combined into a single script. This lets us re-use private network setup and better control the output for user-required information.
* Fix a bug while setting the PATH for psadmin_plus